### PR TITLE
Passing initial_load=true will prevent index-maager reporting back to…

### DIFF
--- a/index_manager/lib/gup_index_manager/resource/gup.ex
+++ b/index_manager/lib/gup_index_manager/resource/gup.ex
@@ -20,8 +20,11 @@ defmodule GupIndexManager.Resource.Gup do
 
   def update_gup({:error, error, error_log_data}), do: {:error, error, error_log_data}
 
-  def update_gup({:ok, person_data, _actions}), do: update_gup(person_data)
-  def update_gup(person_data) do
+  def update_gup({:ok, person_data, _actions}, initial_load), do: update_gup(person_data, initial_load)
+  def update_gup(person_data, _initial_load = true) do
+     {:ok, person_data}
+  end
+  def update_gup(person_data, _initial_load = false) do
     compose_updated_data(person_data)
     |> send_updated_data_to_gup()
     {:ok, person_data}

--- a/index_manager/lib/gup_index_manager_web/controllers/person_controller.ex
+++ b/index_manager/lib/gup_index_manager_web/controllers/person_controller.ex
@@ -7,10 +7,11 @@ defmodule GupIndexManagerWeb.PersonController do
 
   def create_or_update(conn,  %{"data" => data, "api_key" => api_key} = params) do
     force_primary_name = Map.get(params, "force_primary_name", false)
+    initial_load = Map.get(params, "initial_load", false)
     Logger.debug "IM:C.create_or_update: force_primary_name: #{inspect(force_primary_name)}"
     case ControllerHelpers.check_api_key(api_key) do
       true ->
-        Persons.Merger.merge(Map.put(data, "force_primary_name", force_primary_name == "true")) |> Persons.Execute.execute_actions() |> GupIndexManager.Resource.Gup.update_gup() |> respond(conn)
+        Persons.Merger.merge(Map.put(data, "force_primary_name", force_primary_name == "true")) |> Persons.Execute.execute_actions() |> GupIndexManager.Resource.Gup.update_gup(initial_load == "true") |> respond(conn)
       false ->
         json Plug.Conn.put_status(conn, 401), %{status: "401", message: "error, unauthorized key"}
     end


### PR DESCRIPTION
… gup.