### PR TITLE
Force high score values for pop-id and xaccount to make them appear on top of result

### DIFF
--- a/index_manager/lib/gup_index_manager/resource/index/config.ex
+++ b/index_manager/lib/gup_index_manager/resource/index/config.ex
@@ -208,6 +208,13 @@ defmodule GupIndexManager.Resource.Index.Config do
           },
           "id" => %{
             "type" => "keyword"
+          },
+          "identifiers" => %{
+            "type" => "nested",
+            "properties" => %{
+              "code" => %{"type" => "keyword"},
+              "value" => %{"type" => "keyword"}
+            }
           }
         }
       }


### PR DESCRIPTION
This MUST have the identifiers field in the index reindexed to be of type "nested" or everything will break.